### PR TITLE
Add xUnit tests for SpacedRepetitionService

### DIFF
--- a/TelegramWordBot.Tests/TelegramWordBot.Tests.csproj
+++ b/TelegramWordBot.Tests/TelegramWordBot.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TelegramWordBot.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/TelegramWordBot.Tests/UpdateProgressTests.cs
+++ b/TelegramWordBot.Tests/UpdateProgressTests.cs
@@ -1,0 +1,49 @@
+using System;
+using TelegramWordBot.Models;
+using TelegramWordBot.Services;
+using Xunit;
+
+namespace TelegramWordBot.Tests;
+
+public class UpdateProgressTests
+{
+    [Fact]
+    public void UpdateProgress_Success_IncreasesRepetitionAndInterval()
+    {
+        var service = new SpacedRepetitionService();
+        var prog = new UserWordProgress
+        {
+            Repetition = 0,
+            Interval_Hours = 0,
+            Ease_Factor = 2.5
+        };
+
+        var before = DateTime.UtcNow;
+        service.UpdateProgress(prog, true);
+        var after = DateTime.UtcNow;
+
+        Assert.Equal(1, prog.Repetition);
+        Assert.Equal(2, prog.Interval_Hours);
+        Assert.InRange(prog.Next_Review, before.AddHours(prog.Interval_Hours), after.AddHours(prog.Interval_Hours + 0.001));
+    }
+
+    [Fact]
+    public void UpdateProgress_Failure_ResetsIntervalAndDecrementsRepetition()
+    {
+        var service = new SpacedRepetitionService();
+        var prog = new UserWordProgress
+        {
+            Repetition = 2,
+            Interval_Hours = 6,
+            Ease_Factor = 2.5
+        };
+
+        var before = DateTime.UtcNow;
+        service.UpdateProgress(prog, false);
+        var after = DateTime.UtcNow;
+
+        Assert.Equal(1, prog.Repetition);
+        Assert.Equal(1, prog.Interval_Hours);
+        Assert.InRange(prog.Next_Review, before.AddHours(prog.Interval_Hours), after.AddHours(prog.Interval_Hours + 0.001));
+    }
+}

--- a/TelegramWordBot.sln
+++ b/TelegramWordBot.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.13.35818.85
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramWordBot", "TelegramWordBot.csproj", "{DDCB96D6-A0E6-47D0-B7D2-0EC42D19C2D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramWordBot.Tests", "TelegramWordBot.Tests\TelegramWordBot.Tests.csproj", "{C5141977-5BC9-44EE-AD6A-CFCFC5BD22C8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{DDCB96D6-A0E6-47D0-B7D2-0EC42D19C2D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DDCB96D6-A0E6-47D0-B7D2-0EC42D19C2D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDCB96D6-A0E6-47D0-B7D2-0EC42D19C2D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5141977-5BC9-44EE-AD6A-CFCFC5BD22C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5141977-5BC9-44EE-AD6A-CFCFC5BD22C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5141977-5BC9-44EE-AD6A-CFCFC5BD22C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5141977-5BC9-44EE-AD6A-CFCFC5BD22C8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add new TelegramWordBot.Tests project using xUnit
- add tests verifying UpdateProgress success and failure cases
- include test project in TelegramWordBot.sln

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68416583bad0832eae140a8916327420