### PR TITLE
Integrate Pixabay image fetch

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -27,8 +27,7 @@ builder.Services.AddSingleton<UserLanguageRepository>();
 builder.Services.AddSingleton<TelegramMessageHelper>();
 builder.Services.AddSingleton<SpacedRepetitionService>();
 builder.Services.AddSingleton<WordImageRepository>();
-builder.Services.AddSingleton<IImageService, ImageService>();
-builder.Services.AddHttpClient();
+builder.Services.AddHttpClient<IImageService, ImageService>();
 
 
 

--- a/Services/PixabayResponse.cs
+++ b/Services/PixabayResponse.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace TelegramWordBot.Services
+{
+    public class PixabayResponse
+    {
+        [JsonPropertyName("hits")]
+        public List<PixabayHit> Hits { get; set; }
+    }
+
+    public class PixabayHit
+    {
+        [JsonPropertyName("largeImageURL")]
+        public string LargeImageURL { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- register `ImageService` as typed HttpClient
- implement image download and Pixabay search
- add models for Pixabay API responses

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_68417b575f28832e971cb7a5550e251c