### PR TITLE
Enable editing of saved words

### DIFF
--- a/Services/KeyboardFactory.cs
+++ b/Services/KeyboardFactory.cs
@@ -20,6 +20,21 @@ public static class KeyboardFactory
         };
     }
 
+    // Подменю для раздела "Мои слова"
+    public static ReplyKeyboardMarkup GetMyWordsMenu()
+    {
+        return new ReplyKeyboardMarkup(new[]
+        {
+            new[] { new KeyboardButton("Показать мои слова") },
+            new[] { new KeyboardButton("Редактировать список") },
+            new[] { new KeyboardButton("Изменить слово") },
+            new[] { new KeyboardButton("⬅️ Назад") }
+        })
+        {
+            ResizeKeyboard = true
+        };
+    }
+
     // Инлайн-кнопки для конкретного слова (например, на карточке)
     public static InlineKeyboardMarkup GetWordCardInline(string word)
     {
@@ -73,6 +88,11 @@ public static class KeyboardFactory
     public static async Task ShowConfigMenuAsync(ITelegramBotClient botClient, ChatId chatId, CancellationToken ct)
     {
         await botClient.SendMessage(chatId, "Настройки:", replyMarkup: GetConfigInline(), cancellationToken: ct);
+    }
+
+    public static async Task ShowMyWordsMenuAsync(ITelegramBotClient botClient, ChatId chatId, CancellationToken ct)
+    {
+        await botClient.SendMessage(chatId, "Мои слова:", replyMarkup: GetMyWordsMenu(), cancellationToken: ct);
     }
 
     public static async Task ShowLearnConfig(ITelegramBotClient botClient, ChatId chatId, Models.User user, CancellationToken ct)

--- a/Services/TelegramMessageHelper.cs
+++ b/Services/TelegramMessageHelper.cs
@@ -119,6 +119,47 @@ public class TelegramMessageHelper
             cancellationToken: ct);
     }
 
+    public async Task<Message> SendWordCardWithEdit(ChatId chatId, string word, string translation, Guid wordId, string? example = null, string? category = null, string? imageUrl = null, CancellationToken ct = default)
+    {
+        var keyboard = new InlineKeyboardMarkup(
+            InlineKeyboardButton.WithCallbackData("✏️ Изменить", $"edit:{wordId}"));
+
+        var text = GenerateWordCardText(word, translation, example, category);
+
+        if (!string.IsNullOrWhiteSpace(imageUrl))
+        {
+            if (IsHttpUrl(imageUrl))
+            {
+                return await _bot.SendPhoto(
+                    chatId: chatId,
+                    photo: new InputFileUrl(imageUrl),
+                    caption: text,
+                    parseMode: ParseMode.Html,
+                    replyMarkup: keyboard,
+                    cancellationToken: ct);
+            }
+            else if (File.Exists(imageUrl))
+            {
+                await using var stream = File.OpenRead(imageUrl);
+                var file = InputFile.FromStream(stream, Path.GetFileName(imageUrl));
+                return await _bot.SendPhoto(
+                    chatId: chatId,
+                    photo: file,
+                    caption: text,
+                    parseMode: ParseMode.Html,
+                    replyMarkup: keyboard,
+                    cancellationToken: ct);
+            }
+        }
+
+        return await _bot.SendMessage(
+            chatId: chatId,
+            text: text,
+            parseMode: ParseMode.Html,
+            replyMarkup: keyboard,
+            cancellationToken: ct);
+    }
+
     public async Task<Message> EditWordCard(ChatId chatId, int messageId, string word, string translation, string? example = null, string? category = null, string? imageUrl = null, CancellationToken ct = default)
     {
         var text = GenerateWordCardText(word, translation, example, category);

--- a/Worker.cs
+++ b/Worker.cs
@@ -144,6 +144,9 @@ namespace TelegramWordBot
                         case "awaiting_currentlanguage":
                             await ProcessChangeCurrentLanguage(user, text, ct);
                             break;
+                        case "awaiting_editsearch":
+                            await ProcessEditSearch(user, text, ct);
+                            break;
                     }
                     return;
                 }
@@ -371,6 +374,31 @@ namespace TelegramWordBot
             }
         }
 
+        private async Task ShowMyWordsForEdit(long chatId, User user, CancellationToken ct)
+        {
+            var native = await _languageRepo.GetByNameAsync(user.Native_Language);
+            var langs = (await _userLangRepository.GetUserLanguagesAsync(user.Id)).ToList();
+
+            foreach (var lang in langs)
+            {
+                var words = (await _userWordRepo.GetWordsByUserId(user.Id, lang.Id)).ToList();
+                foreach (var w in words)
+                {
+                    var tr = await _translationRepo.GetTranslationAsync(w.Id, native.Id);
+                    var imgPath = await GetImagePathAsync(w);
+                    await _msg.SendWordCardWithEdit(
+                        chatId: new ChatId(chatId),
+                        word: w.Base_Text,
+                        translation: tr?.Text ?? string.Empty,
+                        wordId: w.Id,
+                        example: tr?.Examples,
+                        category: lang.Name,
+                        imageUrl: imgPath,
+                        ct: ct);
+                }
+            }
+        }
+
 
         private Task HandleErrorAsync(ITelegramBotClient botClient, Exception exception, CancellationToken ct)
         {
@@ -425,6 +453,10 @@ namespace TelegramWordBot
                     var favText = parts[1];
                     await _msg.SendSuccessAsync(chatId, $"Слово '{favText}' добавлено в избранное", ct);
                     break;
+                case "edit":
+                    var editId = Guid.Parse(parts[1]);
+                    await ProcessEditWord(user, editId, ct);
+                    break;
                 case "set_native":
                     _userStates[userTelegramId] = "awaiting_nativelanguage";
                     await _msg.SendInfoAsync(chatId, "Введите ваш родной язык:", ct);
@@ -449,6 +481,10 @@ namespace TelegramWordBot
                     break;
                 case "switch_lang":
                     await ProcessSwitchLanguage(callback, chatId, user, parts, ct);
+                    break;
+                case "startedit":
+                    var sid = Guid.Parse(parts[1]);
+                    await ProcessEditWord(user, sid, ct);
                     break;
                 case "prev":
                 case "next":
@@ -664,15 +700,15 @@ namespace TelegramWordBot
 
                     await _msg.SendSuccessAsync(chatId, $"Добавлено «{word.Base_Text}»", ct);
                     var imgPath = await GetImagePathAsync(word);
-                    await _msg.SendWordCard(
+                    await _msg.SendWordCardWithEdit(
                         chatId: new ChatId(chatId),
                         word: word.Base_Text,
                         translation: originalText,
+                        wordId: word.Id,
                         example: examplesStr,
                         category: current.Name,
                         imageUrl: imgPath,
-                        ct: ct
-                    );
+                        ct: ct);
                 }
             }
             else
@@ -722,15 +758,15 @@ namespace TelegramWordBot
 
                 await _msg.SendSuccessAsync(chatId, $"Добавлено «{word.Base_Text}»", ct);
                 var imgPath = await GetImagePathAsync(word);
-                await _msg.SendWordCard(
+                await _msg.SendWordCardWithEdit(
                     chatId: new ChatId(chatId),
                     word: word.Base_Text,
                     translation: combinedTranslations,
+                    wordId: word.Id,
                     example: combinedExamples,
                     category: current.Name,
                     imageUrl: imgPath,
-                    ct: ct
-                );
+                    ct: ct);
             }
         }
 
@@ -932,15 +968,45 @@ namespace TelegramWordBot
 
             await _msg.SendSuccessAsync(chatId, $"Обновлено «{word!.Base_Text}»", ct);
             var imgPath = await GetImagePathAsync(word);
-            await _msg.SendWordCard(
+            await _msg.SendWordCardWithEdit(
                 chatId: new ChatId(chatId),
                 word: word.Base_Text,
                 translation: firstText ?? string.Empty,
+                wordId: word.Id,
                 example: firstExample,
                 category: current!.Name,
                 imageUrl: imgPath,
-                ct: ct
-            );
+                ct: ct);
+        }
+
+        private async Task ProcessEditSearch(User user, string query, CancellationToken ct)
+        {
+            var chatId = user.Telegram_Id;
+            query = query.Trim();
+            if (string.IsNullOrEmpty(query))
+            {
+                await _msg.SendErrorAsync(chatId, "Пустой запрос", ct);
+                return;
+            }
+
+            var words = (await _userWordRepo.GetWordsByUserId(user.Id))
+                .Where(w => w.Base_Text.Contains(query, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
+            if (!words.Any())
+            {
+                await _msg.SendErrorAsync(chatId, "Ничего не найдено", ct);
+                return;
+            }
+
+            var buttons = words.Select(w =>
+                new[] { InlineKeyboardButton.WithCallbackData(w.Base_Text, $"startedit:{w.Id}") }).ToList();
+
+            await _botClient.SendMessage(
+                chatId: chatId,
+                text: "Выберите слово:",
+                replyMarkup: new InlineKeyboardMarkup(buttons),
+                cancellationToken: ct);
         }
 
 
@@ -1073,7 +1139,23 @@ namespace TelegramWordBot
             switch (command.ToLowerInvariant())
             {
                 case "📚 мои слова":
+                    await KeyboardFactory.ShowMyWordsMenuAsync(_botClient, chatId, ct);
+                    return (true, string.Empty);
+
+                case "показать мои слова":
                     await ShowMyWords(chatId, user, ct);
+                    return (true, string.Empty);
+
+                case "редактировать список":
+                    await ShowMyWordsForEdit(chatId, user, ct);
+                    return (true, string.Empty);
+
+                case "изменить слово":
+                    await _msg.SendInfoAsync(chatId, "Введите слово или его часть:", ct);
+                    return (true, "awaiting_editsearch");
+
+                case "⬅️ назад":
+                    await KeyboardFactory.ShowMainMenuAsync(_botClient, chatId, ct);
                     return (true, string.Empty);
 
                 case "➕ добавить слово":


### PR DESCRIPTION
## Summary
- add inline button for editing and supporting method
- create submenu for "Мои слова" and implement command handling
- allow editing search by word
- support showing word list for edit
- send edit-enabled cards when adding or editing words

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68418b3082e0832eaa7c90e01bac2fe4