### PR TITLE
Enable editing of saved words

### DIFF
--- a/Repositories/UserWordRepository.cs
+++ b/Repositories/UserWordRepository.cs
@@ -53,6 +53,14 @@ public class UserWordRepository
         return affectedRows > 0;
     }
 
+    public async Task<bool> RemoveUserWordAsync(Guid userId, Guid wordId)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = @"DELETE FROM user_words WHERE user_id = @User_Id AND word_id = @Word_Id";
+        var affectedRows = await conn.ExecuteAsync(sql, new { User_Id = userId, Word_Id = wordId });
+        return affectedRows > 0;
+    }
+
 
     public async Task<IEnumerable<Word>> GetWordsByUserId(Guid? userId)
     {

--- a/Services/KeyboardFactory.cs
+++ b/Services/KeyboardFactory.cs
@@ -20,6 +20,21 @@ public static class KeyboardFactory
         };
     }
 
+    // Подменю для раздела "Мои слова"
+    public static ReplyKeyboardMarkup GetMyWordsMenu()
+    {
+        return new ReplyKeyboardMarkup(new[]
+        {
+            new[] { new KeyboardButton("Показать мои слова") },
+            new[] { new KeyboardButton("Редактировать список") },
+            new[] { new KeyboardButton("Изменить слово") },
+            new[] { new KeyboardButton("⬅️ Назад") }
+        })
+        {
+            ResizeKeyboard = true
+        };
+    }
+
     // Инлайн-кнопки для конкретного слова (например, на карточке)
     public static InlineKeyboardMarkup GetWordCardInline(string word)
     {
@@ -73,6 +88,11 @@ public static class KeyboardFactory
     public static async Task ShowConfigMenuAsync(ITelegramBotClient botClient, ChatId chatId, CancellationToken ct)
     {
         await botClient.SendMessage(chatId, "Настройки:", replyMarkup: GetConfigInline(), cancellationToken: ct);
+    }
+
+    public static async Task ShowMyWordsMenuAsync(ITelegramBotClient botClient, ChatId chatId, CancellationToken ct)
+    {
+        await botClient.SendMessage(chatId, "Мои слова:", replyMarkup: GetMyWordsMenu(), cancellationToken: ct);
     }
 
     public static async Task ShowLearnConfig(ITelegramBotClient botClient, ChatId chatId, Models.User user, CancellationToken ct)

--- a/Services/TelegramMessageHelper.cs
+++ b/Services/TelegramMessageHelper.cs
@@ -119,6 +119,47 @@ public class TelegramMessageHelper
             cancellationToken: ct);
     }
 
+    public async Task<Message> SendWordCardWithEdit(ChatId chatId, string word, string translation, Guid wordId, string? example = null, string? category = null, string? imageUrl = null, CancellationToken ct = default)
+    {
+        var keyboard = new InlineKeyboardMarkup(
+            InlineKeyboardButton.WithCallbackData("✏️ Изменить", $"edit:{wordId}"));
+
+        var text = GenerateWordCardText(word, translation, example, category);
+
+        if (!string.IsNullOrWhiteSpace(imageUrl))
+        {
+            if (IsHttpUrl(imageUrl))
+            {
+                return await _bot.SendPhoto(
+                    chatId: chatId,
+                    photo: new InputFileUrl(imageUrl),
+                    caption: text,
+                    parseMode: ParseMode.Html,
+                    replyMarkup: keyboard,
+                    cancellationToken: ct);
+            }
+            else if (File.Exists(imageUrl))
+            {
+                await using var stream = File.OpenRead(imageUrl);
+                var file = InputFile.FromStream(stream, Path.GetFileName(imageUrl));
+                return await _bot.SendPhoto(
+                    chatId: chatId,
+                    photo: file,
+                    caption: text,
+                    parseMode: ParseMode.Html,
+                    replyMarkup: keyboard,
+                    cancellationToken: ct);
+            }
+        }
+
+        return await _bot.SendMessage(
+            chatId: chatId,
+            text: text,
+            parseMode: ParseMode.Html,
+            replyMarkup: keyboard,
+            cancellationToken: ct);
+    }
+
     public async Task<Message> EditWordCard(ChatId chatId, int messageId, string word, string translation, string? example = null, string? category = null, string? imageUrl = null, CancellationToken ct = default)
     {
         var text = GenerateWordCardText(word, translation, example, category);


### PR DESCRIPTION
## Summary
- add inline button for editing and supporting method
- create submenu for "Мои слова" and implement command handling
- allow editing search by word
- support showing word list for edit
- send edit-enabled cards when adding or editing words
- allow deleting words via numbered list with pagination

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418b3082e0832eaa7c90e01bac2fe4