### PR TITLE
Add Todo item controller and fields

### DIFF
--- a/Controllers/TodoItemsController.cs
+++ b/Controllers/TodoItemsController.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc;
+using TelegramWordBot.Models;
+using TelegramWordBot.Repositories;
+
+namespace TelegramWordBot.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class TodoItemsController : ControllerBase
+{
+    private readonly TodoItemRepository _repo;
+
+    public TodoItemsController(TodoItemRepository repo)
+    {
+        _repo = repo;
+    }
+
+    [HttpGet]
+    public async Task<IEnumerable<TodoItem>> Get()
+    {
+        return await _repo.GetAllAsync();
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<TodoItem>> Post([FromBody] TodoItem item)
+    {
+        item.Id = Guid.NewGuid();
+        item.Created_At = DateTime.UtcNow;
+        await _repo.AddAsync(item);
+        return CreatedAtAction(nameof(Get), new { id = item.Id }, item);
+    }
+}

--- a/DbInitializer.cs
+++ b/DbInitializer.cs
@@ -62,6 +62,13 @@ public static class DatabaseInitializer
                 id UUID PRIMARY KEY,
                 word_id UUID REFERENCES words(id) ON DELETE CASCADE,
                 file_path TEXT NOT NULL
+            );",
+            @"CREATE TABLE IF NOT EXISTS todo_items (
+                id UUID PRIMARY KEY,
+                title TEXT NOT NULL,
+                description TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL,
+                is_complete BOOLEAN NOT NULL DEFAULT FALSE
             );"
         };
 

--- a/Models/TodoItem.cs
+++ b/Models/TodoItem.cs
@@ -1,0 +1,10 @@
+namespace TelegramWordBot.Models;
+
+public class TodoItem
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public DateTime Created_At { get; set; }
+    public bool Is_Complete { get; set; } = false;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,8 +2,19 @@ using Telegram.Bot;
 using TelegramWordBot;
 using TelegramWordBot.Repositories;
 using TelegramWordBot.Services;
+using TelegramWordBot.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 
-var builder = Host.CreateApplicationBuilder(args);
+var builder = WebApplication.CreateBuilder(args);
+
+var appUrl = Environment.GetEnvironmentVariable("APP_URL");
+if (!string.IsNullOrEmpty(appUrl))
+{
+    builder.WebHost.UseUrls(appUrl);
+}
 
 var connectionString = Environment.GetEnvironmentVariable("CONNECTION_STRING")
     ?? throw new InvalidOperationException("CONNECTION_STRING environment variable is not set.");
@@ -30,11 +41,14 @@ builder.Services.AddSingleton<TelegramMessageHelper>();
 builder.Services.AddSingleton<SpacedRepetitionService>();
 builder.Services.AddSingleton<WordImageRepository>();
 builder.Services.AddHttpClient<IImageService, ImageService>();
+builder.Services.AddSingleton<TodoItemRepository>();
 
-
-
+builder.Services.AddControllers();
 
 builder.Services.AddHostedService<Worker>();
 
-var host = builder.Build();
-host.Run();
+var app = builder.Build();
+
+app.MapControllers();
+
+app.Run();

--- a/Repositories/TodoItemRepository.cs
+++ b/Repositories/TodoItemRepository.cs
@@ -1,0 +1,27 @@
+using Dapper;
+using TelegramWordBot.Models;
+
+namespace TelegramWordBot.Repositories;
+
+public class TodoItemRepository
+{
+    private readonly DbConnectionFactory _factory;
+
+    public TodoItemRepository(DbConnectionFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task<IEnumerable<TodoItem>> GetAllAsync()
+    {
+        using var conn = _factory.CreateConnection();
+        return await conn.QueryAsync<TodoItem>("SELECT * FROM todo_items");
+    }
+
+    public async Task AddAsync(TodoItem item)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = "INSERT INTO todo_items (id, title, description, created_at, is_complete) VALUES (@Id, @Title, @Description, @Created_At, @Is_Complete)";
+        await conn.ExecuteAsync(sql, item);
+    }
+}


### PR DESCRIPTION
## Summary
- expand TodoItem model with description and created date
- create API controller for Todo items
- register controllers instead of minimal API
- update table and repository for new fields

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc1c0cfc832ea510786b0f061e94