### PR TITLE
Update menu structure with new stubs

### DIFF
--- a/Services/KeyboardFactory.cs
+++ b/Services/KeyboardFactory.cs
@@ -12,8 +12,8 @@ public static class KeyboardFactory
         return new ReplyKeyboardMarkup(new[]
         {
             new[] { new KeyboardButton("📚 Мои слова"), new KeyboardButton("➕ Добавить слово") },
-            new[] { new KeyboardButton("📖 Учить"), new KeyboardButton("⚙️ Настройки") },
-            new[] { new KeyboardButton("📊 Статистика"), new KeyboardButton("❓ Помощь") }
+            new[] { new KeyboardButton("📊 Статистика"), new KeyboardButton("📖 Учить") },
+            new[] { new KeyboardButton("🌐 Настройки"), new KeyboardButton("👤 Профиль") }
         })
         {
             ResizeKeyboard = true
@@ -25,9 +25,11 @@ public static class KeyboardFactory
     {
         return new ReplyKeyboardMarkup(new[]
         {
-            new[] { new KeyboardButton("Показать мои слова") },
-            new[] { new KeyboardButton("Редактировать список") },
-            new[] { new KeyboardButton("Изменить слово") },
+            new[] { new KeyboardButton("🔍 Показать все слова") },
+            new[] { new KeyboardButton("📁 Словари по темам") },
+            new[] { new KeyboardButton("🏧 Словари по языкам") },
+            new[] { new KeyboardButton("📝 Изменить слово") },
+            new[] { new KeyboardButton("♻️ Обнулить прогресс слов") },
             new[] { new KeyboardButton("⬅️ Назад") }
         })
         {
@@ -54,11 +56,12 @@ public static class KeyboardFactory
     {
         return new InlineKeyboardMarkup(new[]
         {
-            new[] { InlineKeyboardButton.WithCallbackData("🌐 Выбрать другой язык", "switch_language") },
-            new[] { InlineKeyboardButton.WithCallbackData("➕ Добавить новый язык", "add_foreign") },
-            new[] { InlineKeyboardButton.WithCallbackData("➖ Удалить текущий язык", "remove_foreign") },
-            new[] { InlineKeyboardButton.WithCallbackData("🌐 Изменить родной язык", "set_native") },
-            new[] { InlineKeyboardButton.WithCallbackData("Режим обучения", "config_learn:main") }
+            new[] { InlineKeyboardButton.WithCallbackData("🌐 Выбрать язык изучения", "switch_language") },
+            new[] { InlineKeyboardButton.WithCallbackData("➕ Добавить язык", "add_foreign") },
+            new[] { InlineKeyboardButton.WithCallbackData("🔿️ Удалить язык", "remove_foreign") },
+            new[] { InlineKeyboardButton.WithCallbackData("🌐 Родной язык", "set_native") },
+            new[] { InlineKeyboardButton.WithCallbackData("🎓 Режим обучения", "config_learn:main") },
+            new[] { InlineKeyboardButton.WithCallbackData("❓ Помощь", "help_info") }
         });
     }
 
@@ -75,6 +78,41 @@ public static class KeyboardFactory
         {
             new[] { InlineKeyboardButton.WithCallbackData("✅ Вспомнил/Не вспомнил", "config_learn:binary") },
             new[] { InlineKeyboardButton.WithCallbackData("Выбор из вариантов", "config_learn:multiple") }
+        });
+    }
+
+    // Инлайн-клавиатура для меню статистики
+    public static InlineKeyboardMarkup GetStatisticsInline()
+    {
+        return new InlineKeyboardMarkup(new[]
+        {
+            new[] { InlineKeyboardButton.WithCallbackData("📅 За сегодня", "stat_today") },
+            new[] { InlineKeyboardButton.WithCallbackData("📈 Общий прогресс", "stat_total") },
+            new[] { InlineKeyboardButton.WithCallbackData("🔍 По языкам", "stat_languages") }
+        });
+    }
+
+    // Инлайн-клавиатура для профиля
+    public static InlineKeyboardMarkup GetProfileInline()
+    {
+        return new InlineKeyboardMarkup(new[]
+        {
+            new[] { InlineKeyboardButton.WithCallbackData("👤 Инфо о пользователе", "profile_info") },
+            new[] { InlineKeyboardButton.WithCallbackData("🔄 Сбросить статистику", "reset_profile_stats") }
+        });
+    }
+
+    // Инлайн-кнопки для управления словарями
+    public static InlineKeyboardMarkup GetDictionaryManageInline(int id)
+    {
+        return new InlineKeyboardMarkup(new[]
+        {
+            new[]
+            {
+                InlineKeyboardButton.WithCallbackData("✏️ Редактировать", $"edit_dict:{id}"),
+                InlineKeyboardButton.WithCallbackData("🔄 Обнулить прогресс", $"reset_dict:{id}"),
+                InlineKeyboardButton.WithCallbackData("🗑️ Удалить словарь", $"delete_dict:{id}")
+            }
         });
     }
 
@@ -98,6 +136,18 @@ public static class KeyboardFactory
     public static async Task ShowLearnConfig(ITelegramBotClient botClient, ChatId chatId, Models.User user, CancellationToken ct)
     {
         await botClient.SendMessage(chatId, "Режим показа слов при обучении", replyMarkup: GetConfigLearnInline(user), cancellationToken: ct);
+    }
+
+    // Отображение меню статистики
+    public static async Task ShowStatisticsMenuAsync(ITelegramBotClient botClient, ChatId chatId, CancellationToken ct)
+    {
+        await botClient.SendMessage(chatId, "Статистика:", replyMarkup: GetStatisticsInline(), cancellationToken: ct);
+    }
+
+    // Отображение меню профиля
+    public static async Task ShowProfileMenuAsync(ITelegramBotClient botClient, ChatId chatId, CancellationToken ct)
+    {
+        await botClient.SendMessage(chatId, "Профиль:", replyMarkup: GetProfileInline(), cancellationToken: ct);
     }
 
 

--- a/Worker.cs
+++ b/Worker.cs
@@ -585,6 +585,33 @@ namespace TelegramWordBot
                 case "next":
                     await HandleSliderNavigationAsync(callback, user, parts, ct);
                     break;
+                case "stat_today":
+                    await ShowTodayStatistics(user, chatId, ct); // TODO implement statistics for today
+                    break;
+                case "stat_total":
+                    await ShowStatisticsAsync(user, chatId, ct);
+                    break;
+                case "stat_languages":
+                    await ShowStatisticsByLanguages(user, chatId, ct); // TODO implement stats grouped by languages
+                    break;
+                case "profile_info":
+                    await ShowProfileInfo(user, chatId, ct); // TODO implement profile info display
+                    break;
+                case "reset_profile_stats":
+                    await ResetProfileStatistics(user, chatId, ct); // TODO implement profile stats reset
+                    break;
+                case "edit_dict":
+                    await EditDictionary(parts[1], chatId, ct); // TODO implement dictionary editing
+                    break;
+                case "reset_dict":
+                    await ResetDictionaryProgress(parts[1], chatId, ct); // TODO implement dictionary progress reset
+                    break;
+                case "delete_dict":
+                    await DeleteDictionary(parts[1], chatId, ct); // TODO implement dictionary deletion
+                    break;
+                case "help_info":
+                    await ShowHelpInformation(chatId, ct); // TODO implement help output
+                    break;
                 case "config_learn":
                     switch (parts[1])
                     {
@@ -1223,17 +1250,25 @@ namespace TelegramWordBot
                     await KeyboardFactory.ShowMyWordsMenuAsync(_botClient, chatId, ct);
                     return (true, string.Empty);
 
-                case "показать мои слова":
+                case "🔍 показать все слова":
                     await ShowMyWords(chatId, user, ct);
                     return (true, string.Empty);
 
-                case "редактировать список":
-                    await ShowMyWordsForEdit(chatId, user, ct);
+                case "📁 словари по темам":
+                    await ShowDictionariesByTopics(chatId, ct); // TODO implement listing dictionaries by topics
                     return (true, string.Empty);
 
-                case "изменить слово":
+                case "🏧 словари по языкам":
+                    await ShowDictionariesByLanguages(chatId, ct); // TODO implement listing dictionaries by languages
+                    return (true, string.Empty);
+
+                case "📝 изменить слово":
                     await _msg.SendInfoAsync(chatId, "Введите слово или его часть:", ct);
                     return (true, "awaiting_editsearch");
+
+                case "♻️ обнулить прогресс слов":
+                    await ResetAllWordProgress(chatId, user, ct); // TODO reset learning progress for all words
+                    return (true, string.Empty);
 
                 case "⬅️ назад":
                     await KeyboardFactory.ShowMainMenuAsync(_botClient, chatId, ct);
@@ -1248,19 +1283,16 @@ namespace TelegramWordBot
                     await StartLearningAsync(user, ct);
                     return (true, string.Empty);
 
-                case "⚙️ настройки":
+                case "🌐 настройки":
                     await KeyboardFactory.ShowConfigMenuAsync(_botClient, chatId, ct);
                     return (true, string.Empty);
 
                 case "📊 статистика":
-                    await ShowStatisticsAsync(user, chatId, ct);
+                    await KeyboardFactory.ShowStatisticsMenuAsync(_botClient, chatId, ct);
                     return (true, string.Empty);
 
-                case "❓ помощь":
-                    await _botClient.SendMessage(
-                        chatId,
-                        "Я бот для изучения слов. Используй меню или команды: /addword, /learn, /config",
-                        cancellationToken: ct);
+                case "👤 профиль":
+                    await KeyboardFactory.ShowProfileMenuAsync(_botClient, chatId, ct);
                     return (true, string.Empty);
 
                 default:
@@ -1867,6 +1899,74 @@ namespace TelegramWordBot
 
             // 6) Отправляем одним сообщением
             await _msg.SendText(chatId, sb.ToString(), ct);
+        }
+
+        // === New stub methods ===
+
+        private Task ShowTodayStatistics(User user, ChatId chatId, CancellationToken ct)
+        {
+            // TODO: calculate and display statistics only for current day
+            return _msg.SendInfoAsync(chatId, "Статистика за сегодня в разработке", ct);
+        }
+
+        private Task ShowStatisticsByLanguages(User user, ChatId chatId, CancellationToken ct)
+        {
+            // TODO: group statistics by learning languages and display separate blocks
+            return _msg.SendInfoAsync(chatId, "Статистика по языкам в разработке", ct);
+        }
+
+        private Task ShowDictionariesByTopics(long chatId, CancellationToken ct)
+        {
+            // TODO: show list of user dictionaries grouped by topics
+            return _msg.SendInfoAsync(chatId, "Списки словарей по темам в разработке", ct);
+        }
+
+        private Task ShowDictionariesByLanguages(long chatId, CancellationToken ct)
+        {
+            // TODO: show list of dictionaries grouped by languages
+            return _msg.SendInfoAsync(chatId, "Списки словарей по языкам в разработке", ct);
+        }
+
+        private Task ResetAllWordProgress(long chatId, User user, CancellationToken ct)
+        {
+            // TODO: reset spaced repetition progress for all words of the user
+            return _msg.SendInfoAsync(chatId, "Сброс прогресса слов в разработке", ct);
+        }
+
+        private Task ShowProfileInfo(User user, ChatId chatId, CancellationToken ct)
+        {
+            // TODO: display detailed profile information
+            return _msg.SendInfoAsync(chatId, "Профиль пользователя в разработке", ct);
+        }
+
+        private Task ResetProfileStatistics(User user, ChatId chatId, CancellationToken ct)
+        {
+            // TODO: clear all learning statistics for the user
+            return _msg.SendInfoAsync(chatId, "Сброс статистики профиля в разработке", ct);
+        }
+
+        private Task EditDictionary(string id, long chatId, CancellationToken ct)
+        {
+            // TODO: open dictionary editing flow by id
+            return _msg.SendInfoAsync(chatId, $"Редактирование словаря {id} в разработке", ct);
+        }
+
+        private Task ResetDictionaryProgress(string id, long chatId, CancellationToken ct)
+        {
+            // TODO: reset spaced repetition progress for all words inside dictionary
+            return _msg.SendInfoAsync(chatId, $"Сброс прогресса словаря {id} в разработке", ct);
+        }
+
+        private Task DeleteDictionary(string id, long chatId, CancellationToken ct)
+        {
+            // TODO: remove dictionary by id
+            return _msg.SendInfoAsync(chatId, $"Удаление словаря {id} в разработке", ct);
+        }
+
+        private Task ShowHelpInformation(long chatId, CancellationToken ct)
+        {
+            // TODO: show help information about using the bot
+            return _msg.SendInfoAsync(chatId, "Справочная информация в разработке", ct);
         }
     }
 }


### PR DESCRIPTION
## Summary
- adapt main and sub menus to new structure
- add inline keyboards for statistics, profile and dictionaries
- update worker command and callback handling for new buttons
- include placeholder methods for future functionality

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6843f5ac7710832e8aeef05bb8b0852e