### PR TITLE
Add user dictionaries data model

### DIFF
--- a/DbInitializer.cs
+++ b/DbInitializer.cs
@@ -63,6 +63,17 @@ public static class DatabaseInitializer
                 word_id UUID REFERENCES words(id) ON DELETE CASCADE,
                 file_path TEXT NOT NULL
             );",
+            @"CREATE TABLE IF NOT EXISTS dictionaries (
+                id UUID PRIMARY KEY,
+                user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+                name TEXT NOT NULL,
+                UNIQUE(user_id, name)
+            );",
+            @"CREATE TABLE IF NOT EXISTS dictionary_words (
+                dictionary_id UUID REFERENCES dictionaries(id) ON DELETE CASCADE,
+                word_id UUID REFERENCES words(id) ON DELETE CASCADE,
+                PRIMARY KEY(dictionary_id, word_id)
+            );",
             @"CREATE TABLE IF NOT EXISTS todo_items (
                 id UUID PRIMARY KEY,
                 title TEXT NOT NULL,

--- a/Models/Dictionary.cs
+++ b/Models/Dictionary.cs
@@ -1,0 +1,8 @@
+namespace TelegramWordBot.Models;
+
+public class Dictionary
+{
+    public Guid Id { get; set; }
+    public Guid User_Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/Models/DictionaryWord.cs
+++ b/Models/DictionaryWord.cs
@@ -1,0 +1,7 @@
+namespace TelegramWordBot.Models;
+
+public class DictionaryWord
+{
+    public Guid Dictionary_Id { get; set; }
+    public Guid Word_Id { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddSingleton<UserRepository>();
 builder.Services.AddSingleton<UserWordProgressRepository>();
 builder.Services.AddSingleton<LanguageRepository>();
 builder.Services.AddSingleton<UserWordRepository>();
+builder.Services.AddSingleton<DictionaryRepository>();
 builder.Services.AddHttpClient<IAIHelper, AIHelper>();
 builder.Services.AddSingleton<TranslationRepository>();
 builder.Services.AddSingleton<UserLanguageRepository>();

--- a/Repositories/DictionaryRepository.cs
+++ b/Repositories/DictionaryRepository.cs
@@ -1,0 +1,49 @@
+using Dapper;
+using TelegramWordBot.Models;
+
+namespace TelegramWordBot.Repositories;
+
+public class DictionaryRepository
+{
+    private readonly DbConnectionFactory _factory;
+
+    public DictionaryRepository(DbConnectionFactory factory)
+    {
+        _factory = factory;
+    }
+
+    public async Task AddAsync(Dictionary dict)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = @"INSERT INTO dictionaries (id, user_id, name) VALUES (@Id, @User_Id, @Name)";
+        await conn.ExecuteAsync(sql, dict);
+    }
+
+    public async Task<IEnumerable<Dictionary>> GetByUserAsync(Guid userId)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = @"SELECT id AS Id, user_id AS User_Id, name AS Name FROM dictionaries WHERE user_id = @User_Id";
+        return await conn.QueryAsync<Dictionary>(sql, new { User_Id = userId });
+    }
+
+    public async Task AddWordAsync(Guid dictionaryId, Guid wordId)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = @"INSERT INTO dictionary_words (dictionary_id, word_id) VALUES (@Dictionary_Id, @Word_Id) ON CONFLICT DO NOTHING";
+        await conn.ExecuteAsync(sql, new { Dictionary_Id = dictionaryId, Word_Id = wordId });
+    }
+
+    public async Task RemoveWordAsync(Guid dictionaryId, Guid wordId)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = @"DELETE FROM dictionary_words WHERE dictionary_id = @Dictionary_Id AND word_id = @Word_Id";
+        await conn.ExecuteAsync(sql, new { Dictionary_Id = dictionaryId, Word_Id = wordId });
+    }
+
+    public async Task<IEnumerable<Word>> GetWordsAsync(Guid dictionaryId)
+    {
+        using var conn = _factory.CreateConnection();
+        const string sql = @"SELECT w.id AS Id, w.base_text AS Base_Text, w.language_id AS Language_Id FROM dictionary_words dw JOIN words w ON dw.word_id = w.id WHERE dw.dictionary_id = @Dictionary_Id";
+        return await conn.QueryAsync<Word>(sql, new { Dictionary_Id = dictionaryId });
+    }
+}


### PR DESCRIPTION
## Summary
- add models `Dictionary` and `DictionaryWord`
- add `DictionaryRepository` for CRUD helpers
- register new repository
- extend DB initializer with dictionary tables

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68440503e07c832e8e1c269f49516a8b