### PR TITLE
Add user-specific Todo items with Telegram commands

### DIFF
--- a/Controllers/TodoItemsController.cs
+++ b/Controllers/TodoItemsController.cs
@@ -16,18 +16,19 @@ public class TodoItemsController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<IEnumerable<TodoItem>> Get()
+    public async Task<IEnumerable<TodoItem>> Get([FromQuery] Guid userId)
     {
-        return await _repo.GetAllAsync();
+        return await _repo.GetAllAsync(userId);
     }
 
     [HttpPost]
-    public async Task<ActionResult<TodoItem>> Post([FromBody] TodoItem item)
+    public async Task<ActionResult<TodoItem>> Post([FromQuery] Guid userId, [FromBody] TodoItem item)
     {
         item.Id = Guid.NewGuid();
+        item.User_Id = userId;
         item.Created_At = DateTime.UtcNow;
         await _repo.AddAsync(item);
-        return CreatedAtAction(nameof(Get), new { id = item.Id }, item);
+        return CreatedAtAction(nameof(Get), new { id = item.Id, userId = userId }, item);
     }
 
     [HttpPost("{id}/complete")]
@@ -40,14 +41,14 @@ public class TodoItemsController : ControllerBase
         item.Is_Complete = true;
         await _repo.UpdateAsync(item);
 
-        return RedirectToAction(nameof(GetPretty));
+        return RedirectToAction(nameof(GetPretty), new { userId = item.User_Id });
     }
 
 
     [HttpGet("pretty")]
-    public async Task<IActionResult> GetPretty()
+    public async Task<IActionResult> GetPretty([FromQuery] Guid userId)
     {
-        var items = await _repo.GetAllAsync();
+        var items = await _repo.GetAllAsync(userId);
         var html = $@"
     <html>
     <head>

--- a/DbInitializer.cs
+++ b/DbInitializer.cs
@@ -76,6 +76,7 @@ public static class DatabaseInitializer
             );",
             @"CREATE TABLE IF NOT EXISTS todo_items (
                 id UUID PRIMARY KEY,
+                user_id UUID REFERENCES users(id) ON DELETE CASCADE,
                 title TEXT NOT NULL,
                 description TEXT NOT NULL,
                 created_at TIMESTAMPTZ NOT NULL,

--- a/Models/TodoItem.cs
+++ b/Models/TodoItem.cs
@@ -3,6 +3,7 @@ namespace TelegramWordBot.Models;
 public class TodoItem
 {
     public Guid Id { get; set; }
+    public Guid User_Id { get; set; }
     public string Title { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
     public DateTime Created_At { get; set; }

--- a/Repositories/TodoItemRepository.cs
+++ b/Repositories/TodoItemRepository.cs
@@ -12,19 +12,19 @@ public class TodoItemRepository
         _factory = factory;
     }
 
-    public async Task<IEnumerable<TodoItem>> GetAllAsync()
+    public async Task<IEnumerable<TodoItem>> GetAllAsync(Guid userId)
     {
         using var conn = _factory.CreateConnection();
         IEnumerable<TodoItem> items = await conn.QueryAsync<TodoItem>(
-    "SELECT * FROM todo_items ORDER BY is_complete ASC, created_at DESC"
-);
+            "SELECT * FROM todo_items WHERE user_id = @User_Id ORDER BY is_complete ASC, created_at DESC",
+            new { User_Id = userId });
         return items;
     }
 
     public async Task AddAsync(TodoItem item)
     {
         using var conn = _factory.CreateConnection();
-        const string sql = "INSERT INTO todo_items (id, title, description, created_at, is_complete) VALUES (@Id, @Title, @Description, @Created_At, @Is_Complete)";
+        const string sql = "INSERT INTO todo_items (id, user_id, title, description, created_at, is_complete) VALUES (@Id, @User_Id, @Title, @Description, @Created_At, @Is_Complete)";
         await conn.ExecuteAsync(sql, item);
     }
 


### PR DESCRIPTION
## Summary
- link todo items to users in DB and model
- filter TodoItem endpoints by user
- add /todo and /todos bot commands

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846867ee454832e854f17514059cf2f