### PR TITLE
Fix font fallback in GeneratePngFramedText

### DIFF
--- a/Functions.cs
+++ b/Functions.cs
@@ -197,7 +197,12 @@ namespace TelegramWordBot
             int usedFontSize = fontSize;
 
             // Подготовка шрифта
-            FontFamily family = SystemFonts.Families.First(f => f.Name == fontFamily);                                
+            FontFamily family;
+            if (!SystemFonts.TryGet(fontFamily, out family))
+            {
+                family = SystemFonts.Collection.Families.First();
+                Console.WriteLine($"Warning: Font '{fontFamily}' not found. Using '{family.Name}' instead.");
+            }
 
             // Попытка одной строки
             for (int size = fontSize; size >= 12; size--)


### PR DESCRIPTION
## Summary
- prevent GeneratePngFramedText from throwing when a font is missing by using `SystemFonts.TryGet`
- log a console warning when falling back to a default font

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68487e5e1810832ea72872b2c90dab93