### PR TITLE
Add admin-only Todo button and improve task page

### DIFF
--- a/Controllers/TodoItemsController.cs
+++ b/Controllers/TodoItemsController.cs
@@ -31,6 +31,21 @@ public class TodoItemsController : ControllerBase
         return CreatedAtAction(nameof(Get), new { id = item.Id, userId = userId }, item);
     }
 
+    [HttpPost("add")]
+    public async Task<IActionResult> Add([FromQuery] Guid userId, [FromForm] string title, [FromForm] string description)
+    {
+        var item = new TodoItem
+        {
+            Id = Guid.NewGuid(),
+            User_Id = userId,
+            Title = title,
+            Description = description,
+            Created_At = DateTime.UtcNow
+        };
+        await _repo.AddAsync(item);
+        return RedirectToAction(nameof(GetPretty), new { userId });
+    }
+
     [HttpPost("{id}/complete")]
     public async Task<IActionResult> MarkComplete(Guid id)
     {
@@ -62,13 +77,34 @@ public class TodoItemsController : ControllerBase
             .link-btn {{
                 display: inline-block; margin-top: 10px; background: #4267b2; color: #fff; padding: 6px 14px;
                 border-radius: 8px; text-decoration: none; font-size: 0.96em;
-                transition: background 0.2s; 
+                transition: background 0.2s;
             }}
             .link-btn:hover {{ background: #1a418e; }}
         </style>
+        <script>
+            function toggleCompleted() {{
+                var show = document.getElementById('showCompleted').checked;
+                document.querySelectorAll('.done').forEach(function(el) {{
+                    el.style.display = show ? 'block' : 'none';
+                }});
+            }}
+            window.onload = function() {{
+                document.getElementById('showCompleted').checked = false;
+                toggleCompleted();
+            }}
+        </script>
     </head>
     <body>
         <h1>📝 Список задач</h1>
+
+        <form method='post' action='/todoitems/add?userId={userId}' style='margin-bottom:20px;'>
+            <input type='text' name='title' placeholder='Заголовок' required><br>
+            <textarea name='description' placeholder='Описание' rows='3'></textarea><br>
+            <button class='link-btn' type='submit'>Добавить</button>
+        </form>
+
+        <label><input type='checkbox' id='showCompleted' onchange='toggleCompleted()'> Показывать выполненные</label>
+
         <ul style='list-style:none; padding:0;'>
         {string.Join("\n", items.Select(x => $@"
             <li class='item{(x.Is_Complete ? " done" : "")}'>

--- a/Services/KeyboardFactory.cs
+++ b/Services/KeyboardFactory.cs
@@ -95,17 +95,24 @@ public static class KeyboardFactory
     }
 
     // Инлайн-клавиатура для профиля
-    public static InlineKeyboardMarkup GetProfileInline(Guid userId, string appUrl)
+    public static InlineKeyboardMarkup GetProfileInline(Guid userId, long telegramId, string appUrl)
     {
         var baseUrl = string.IsNullOrEmpty(appUrl) ? string.Empty : appUrl.TrimEnd('/');
         var todoUrl = $"{baseUrl}/todoitems/pretty?userId={userId}";
-
-        return new InlineKeyboardMarkup(new[]
+        var rows = new List<InlineKeyboardButton[]>
         {
-            new[] { InlineKeyboardButton.WithCallbackData("👤 Инфо о пользователе", "profile_info") },
-            new[] { InlineKeyboardButton.WithWebApp("📝 Todo App", new WebAppInfo(todoUrl)) },
-            new[] { InlineKeyboardButton.WithCallbackData("🔄 Сбросить статистику", "reset_profile_stats") }
-        });
+            new[] { InlineKeyboardButton.WithCallbackData("👤 Инфо о пользователе", "profile_info") }
+        };
+
+        var adminId = Environment.GetEnvironmentVariable("ADMIN_ID");
+        if (!string.IsNullOrEmpty(adminId) && adminId == telegramId.ToString())
+        {
+            rows.Add(new[] { InlineKeyboardButton.WithWebApp("📝 Todo App", new WebAppInfo(todoUrl)) });
+        }
+
+        rows.Add(new[] { InlineKeyboardButton.WithCallbackData("🔄 Сбросить статистику", "reset_profile_stats") });
+
+        return new InlineKeyboardMarkup(rows);
     }
 
     // Инлайн-кнопки для управления словарями
@@ -199,9 +206,9 @@ public static class KeyboardFactory
     }
 
     // Отображение меню профиля
-    public static async Task ShowProfileMenuAsync(ITelegramBotClient botClient, ChatId chatId, Guid userId, string appUrl, CancellationToken ct)
+    public static async Task ShowProfileMenuAsync(ITelegramBotClient botClient, ChatId chatId, Guid userId, long telegramId, string appUrl, CancellationToken ct)
     {
-        await botClient.SendMessage(chatId, "Профиль:", replyMarkup: GetProfileInline(userId, appUrl), cancellationToken: ct);
+        await botClient.SendMessage(chatId, "Профиль:", replyMarkup: GetProfileInline(userId, telegramId, appUrl), cancellationToken: ct);
     }
         
 }

--- a/Worker.cs
+++ b/Worker.cs
@@ -164,7 +164,7 @@ namespace TelegramWordBot
 
                 case "👤 профиль":
                     string url = _appUrl.StartsWith("http") ? _appUrl.Replace("http", "https") : "https://" + _appUrl;
-                    await KeyboardFactory.ShowProfileMenuAsync(_botClient, chatId, user.Id, url, ct);
+                    await KeyboardFactory.ShowProfileMenuAsync(_botClient, chatId, user.Id, user.Telegram_Id, url, ct);
                     return (true, string.Empty);
                 case "генерация новых слов":
                     await _msg.SendInfoAsync(chatId, "На какую тему добавить слова?:", ct);


### PR DESCRIPTION
## Summary
- show `Todo App` button only to admin user defined via `ADMIN_ID`
- pass telegram ID to profile menu helper
- add ability to add tasks and toggle completed items on the todo page

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68488d6aa354832ea253eb1ef74bbe65