### PR TITLE
Fix IsPremium null-coalescing compile error

### DIFF
--- a/Worker.cs
+++ b/Worker.cs
@@ -1988,7 +1988,7 @@ namespace TelegramWordBot
                     First_Name = message.From.FirstName,
                     Last_Name = message.From.LastName,
                     User_Name = message.From.Username,
-                    Is_Premium = message.From.IsPremium ?? false,
+                    Is_Premium = message.From.IsPremium,
                     Last_Seen = DateTime.UtcNow
                 };
                 await _userRepo.AddAsync(user);
@@ -1998,7 +1998,7 @@ namespace TelegramWordBot
                 user.First_Name = message.From.FirstName;
                 user.Last_Name = message.From.LastName;
                 user.User_Name = message.From.Username;
-                user.Is_Premium = message.From.IsPremium ?? false;
+                user.Is_Premium = message.From.IsPremium;
                 user.Last_Seen = DateTime.UtcNow;
                 await _userRepo.UpdateAsync(user);
             }


### PR DESCRIPTION
## Summary
- fix assignment for `Is_Premium` not using `??` with boolean

## Testing
- `dotnet build TelegramWordBot.sln`
- `dotnet test TelegramWordBot.Tests/TelegramWordBot.Tests.csproj --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_684a84f53dc8832ebca9759c7496da20