### PR TITLE
Add word image counts

### DIFF
--- a/Repositories/WordImageRepository.cs
+++ b/Repositories/WordImageRepository.cs
@@ -42,5 +42,34 @@ namespace TelegramWordBot.Repositories
             await conn.ExecuteAsync(@"
             UPDATE word_images SET file_path = @FilePath WHERE id = @Id", img);
         }
+
+        public async Task<int> CountWithImageAsync()
+        {
+            using var conn = _factory.CreateConnection();
+            const string sql = @"SELECT COUNT(*) FROM words w
+                                    JOIN word_images i ON w.id = i.word_id";
+            return await conn.ExecuteScalarAsync<int>(sql);
+        }
+
+        public async Task<int> CountWithoutImageAsync()
+        {
+            using var conn = _factory.CreateConnection();
+            const string sql = @"SELECT COUNT(*) FROM words w
+                                    LEFT JOIN word_images i ON w.id = i.word_id
+                                    WHERE i.word_id IS NULL";
+            return await conn.ExecuteScalarAsync<int>(sql);
+        }
+
+        public async Task<IEnumerable<Word>> GetWordsWithoutImagesAsync()
+        {
+            using var conn = _factory.CreateConnection();
+            const string sql = @"SELECT w.id AS Id,
+                                       w.base_text AS Base_Text,
+                                       w.language_id AS Language_Id
+                                FROM words w
+                                LEFT JOIN word_images i ON w.id = i.word_id
+                                WHERE i.word_id IS NULL";
+            return await conn.QueryAsync<Word>(sql);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend WordImageRepository with methods to count words with/without images
- support retrieving all words without an attached image

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c780bb584832e83eab99587395386