### PR TITLE
Add admin image download action

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using TelegramWordBot.Repositories;
+using TelegramWordBot.Services;
+
+namespace TelegramWordBot.Controllers;
+
+[ApiController]
+[Route("admin")]
+public class AdminController : ControllerBase
+{
+    private readonly WordImageRepository _imageRepo;
+    private readonly IImageService _imageService;
+
+    public AdminController(WordImageRepository imageRepo, IImageService imageService)
+    {
+        _imageRepo = imageRepo;
+        _imageService = imageService;
+    }
+
+    [HttpPost("images/download")]
+    public async Task<IActionResult> DownloadImages()
+    {
+        var words = (await _imageRepo.GetWordsWithoutImagesAsync()).ToList();
+        int success = 0;
+        int failed = 0;
+        foreach (var w in words)
+        {
+            var path = await _imageService.GetImagePathAsync(w);
+            if (string.IsNullOrEmpty(path))
+                failed++;
+            else
+                success++;
+        }
+
+        return Ok(new { Total = words.Count(), Success = success, Failed = failed });
+    }
+}


### PR DESCRIPTION
## Summary
- expose image fetching logic through `ImageService.GetImagePathAsync`
- update `Worker` to use the service
- add `AdminController` with `/admin/images/download` action

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7986afbc832eb4fbdc618b44922b