### PR TITLE
Add repository unit tests

### DIFF
--- a/Repositories/DictionaryRepository.cs
+++ b/Repositories/DictionaryRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 using Dapper;
 using TelegramWordBot.Models;
 
@@ -5,9 +6,9 @@ namespace TelegramWordBot.Repositories;
 
 public class DictionaryRepository
 {
-    private readonly DbConnectionFactory _factory;
+    private readonly IConnectionFactory _factory;
 
-    public DictionaryRepository(DbConnectionFactory factory)
+    public DictionaryRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }

--- a/Repositories/LanguageRepository.cs
+++ b/Repositories/LanguageRepository.cs
@@ -1,11 +1,12 @@
+using TelegramWordBot;
 using Dapper; 
 using TelegramWordBot.Models;
 
 namespace TelegramWordBot.Repositories { 
     public class LanguageRepository { 
-        private readonly DbConnectionFactory _factory;
+        private readonly IConnectionFactory _factory;
 
-    public LanguageRepository(DbConnectionFactory factory)
+    public LanguageRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }
@@ -35,7 +36,7 @@ namespace TelegramWordBot.Repositories {
     {
             if (string.IsNullOrEmpty(name)) return null;
 
-            // Íîðìàëèçàöèÿ ðåãèñòðà: ïåðâàÿ áóêâà — çàãëàâíàÿ, îñòàëüíûå — ñòðî÷íûå
+            // ÃÃ®Ã°Ã¬Ã Ã«Ã¨Ã§Ã Ã¶Ã¨Ã¿ Ã°Ã¥Ã£Ã¨Ã±Ã²Ã°Ã : Ã¯Ã¥Ã°Ã¢Ã Ã¿ Ã¡Ã³ÃªÃ¢Ã  â€” Ã§Ã Ã£Ã«Ã Ã¢Ã­Ã Ã¿, Ã®Ã±Ã²Ã Ã«Ã¼Ã­Ã»Ã¥ â€” Ã±Ã²Ã°Ã®Ã·Ã­Ã»Ã¥
             string normalizedName = string.Create(name.Length, name, (chars, input) =>
             {
                 for (int i = 0; i < chars.Length; i++)

--- a/Repositories/TodoItemRepository.cs
+++ b/Repositories/TodoItemRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 using Dapper;
 using TelegramWordBot.Models;
 
@@ -5,9 +6,9 @@ namespace TelegramWordBot.Repositories;
 
 public class TodoItemRepository
 {
-    private readonly DbConnectionFactory _factory;
+    private readonly IConnectionFactory _factory;
 
-    public TodoItemRepository(DbConnectionFactory factory)
+    public TodoItemRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }

--- a/Repositories/TranslationRepository.cs
+++ b/Repositories/TranslationRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using System.Transactions;
 using Dapper;
 using TelegramWordBot.Models;
@@ -6,9 +7,9 @@ namespace TelegramWordBot.Repositories;
 
 public class TranslationRepository
 {
-    private readonly DbConnectionFactory _factory;
+    private readonly IConnectionFactory _factory;
 
-    public TranslationRepository(DbConnectionFactory factory)
+    public TranslationRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }

--- a/Repositories/UserLanguageRepository.cs
+++ b/Repositories/UserLanguageRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using Dapper;
 using TelegramWordBot.Models;
 
@@ -5,9 +6,9 @@ namespace TelegramWordBot.Repositories;
 
 public class UserLanguageRepository
 {
-    private readonly DbConnectionFactory _factory;
+    private readonly IConnectionFactory _factory;
 
-    public UserLanguageRepository(DbConnectionFactory factory)
+    public UserLanguageRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }

--- a/Repositories/UserRepository.cs
+++ b/Repositories/UserRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using Dapper;
 using TelegramWordBot.Models;
 
@@ -5,9 +6,9 @@ namespace TelegramWordBot.Repositories;
 
 public class UserRepository
 {
-    private readonly DbConnectionFactory _factory;
+    private readonly IConnectionFactory _factory;
 
-    public UserRepository(DbConnectionFactory factory)
+    public UserRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }

--- a/Repositories/UserWordProgressRepository.cs
+++ b/Repositories/UserWordProgressRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using Dapper;
 using System;
 using System.Collections.Generic;
@@ -8,9 +9,9 @@ namespace TelegramWordBot.Repositories
 {
     public class UserWordProgressRepository
     {
-        private readonly DbConnectionFactory _factory;
+        private readonly IConnectionFactory _factory;
 
-        public UserWordProgressRepository(DbConnectionFactory factory)
+        public UserWordProgressRepository(IConnectionFactory factory)
         {
             _factory = factory;
         }

--- a/Repositories/UserWordRepository.cs
+++ b/Repositories/UserWordRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using Dapper;
 using TelegramWordBot.Models;
 
@@ -5,9 +6,9 @@ namespace TelegramWordBot.Repositories;
 
 public class UserWordRepository
 {
-    private readonly DbConnectionFactory _factory;
+    private readonly IConnectionFactory _factory;
 
-    public UserWordRepository(DbConnectionFactory factory)
+    public UserWordRepository(IConnectionFactory factory)
     {
         _factory = factory;
     }

--- a/Repositories/WordImageRepository.cs
+++ b/Repositories/WordImageRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -11,8 +12,8 @@ namespace TelegramWordBot.Repositories
 
     public class WordImageRepository
     {
-        private readonly DbConnectionFactory _factory;
-        public WordImageRepository(DbConnectionFactory factory) => _factory = factory;
+        private readonly IConnectionFactory _factory;
+        public WordImageRepository(IConnectionFactory factory) => _factory = factory;
 
         public async Task AddAsync(WordImage img)
         {

--- a/Repositories/WordRepository.cs
+++ b/Repositories/WordRepository.cs
@@ -1,3 +1,4 @@
+using TelegramWordBot;
 ﻿using Dapper;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/TelegramWordBot.Tests/GuidTypeHandler.cs
+++ b/TelegramWordBot.Tests/GuidTypeHandler.cs
@@ -1,0 +1,17 @@
+using System.Data;
+using Dapper;
+
+public class GuidTypeHandler : SqlMapper.TypeHandler<Guid>
+{
+    public override Guid Parse(object value)
+    {
+        if (value is byte[] bytes)
+            return new Guid(bytes);
+        return Guid.Parse(value.ToString()!);
+    }
+
+    public override void SetValue(IDbDataParameter parameter, Guid value)
+    {
+        parameter.Value = value.ToString();
+    }
+}

--- a/TelegramWordBot.Tests/LanguageRepositoryTests.cs
+++ b/TelegramWordBot.Tests/LanguageRepositoryTests.cs
@@ -1,0 +1,41 @@
+using Dapper;
+using TelegramWordBot.Models;
+using TelegramWordBot.Repositories;
+using Xunit;
+
+public class LanguageRepositoryTests : IDisposable
+{
+    private readonly TestDbConnectionFactory _factory;
+    private readonly LanguageRepository _repo;
+
+    public LanguageRepositoryTests()
+    {
+        _factory = new TestDbConnectionFactory();
+        using var conn = _factory.CreateConnection();
+        conn.Execute("CREATE TABLE languages (id INTEGER PRIMARY KEY AUTOINCREMENT, code TEXT NOT NULL UNIQUE, name TEXT NOT NULL UNIQUE);");
+        _repo = new LanguageRepository(_factory);
+    }
+
+    [Fact]
+    public async Task AddAndGetByCodeAsync()
+    {
+        var lang = new Language { Code = "en", Name = "English" };
+        await _repo.AddAsync(lang);
+
+        var loaded = await _repo.GetByCodeAsync("EN");
+
+        Assert.NotNull(loaded);
+        Assert.Equal("en", loaded!.Code);
+    }
+
+    [Fact]
+    public async Task GetByNameAsync_NormalizesName()
+    {
+        await _repo.AddAsync(new Language { Code = "ru", Name = "Russian" });
+        var loaded = await _repo.GetByNameAsync("RUSSIAN");
+        Assert.NotNull(loaded);
+        Assert.Equal("Russian", loaded!.Name);
+    }
+
+    public void Dispose() => _factory.Dispose();
+}

--- a/TelegramWordBot.Tests/TelegramWordBot.Tests.csproj
+++ b/TelegramWordBot.Tests/TelegramWordBot.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TelegramWordBot.Tests/TestDbConnectionFactory.cs
+++ b/TelegramWordBot.Tests/TestDbConnectionFactory.cs
@@ -1,0 +1,37 @@
+using System.Data;
+using Microsoft.Data.Sqlite;
+using TelegramWordBot;
+
+public class TestDbConnectionFactory : IConnectionFactory, IDisposable
+{
+    private readonly string _connectionString;
+    private readonly string _dbPath;
+
+    public TestDbConnectionFactory()
+    {
+        _dbPath = Path.GetTempFileName();
+        _connectionString = $"Data Source={_dbPath}";
+    }
+
+    public TestDbConnectionFactory(string connectionString)
+    {
+        _connectionString = connectionString;
+        var builder = new SqliteConnectionStringBuilder(connectionString);
+        _dbPath = builder.DataSource ?? string.Empty;
+    }
+
+    public IDbConnection CreateConnection()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        conn.Open();
+        return conn;
+    }
+
+    public void Dispose()
+    {
+        if (!string.IsNullOrEmpty(_dbPath) && File.Exists(_dbPath))
+        {
+            try { File.Delete(_dbPath); } catch { }
+        }
+    }
+}

--- a/TelegramWordBot.Tests/UserRepositoryTests.cs
+++ b/TelegramWordBot.Tests/UserRepositoryTests.cs
@@ -1,0 +1,53 @@
+using Dapper;
+using TelegramWordBot.Models;
+using TelegramWordBot.Repositories;
+using Xunit;
+
+public class UserRepositoryTests : IDisposable
+{
+static UserRepositoryTests() { SqlMapper.AddTypeHandler(new GuidTypeHandler()); }
+    private readonly TestDbConnectionFactory _factory;
+    private readonly UserRepository _repo;
+
+    public UserRepositoryTests()
+    {
+        _factory = new TestDbConnectionFactory();
+        using var conn = _factory.CreateConnection();
+        conn.Execute(@"CREATE TABLE users (
+            id BLOB PRIMARY KEY,
+            telegram_id INTEGER NOT NULL,
+            native_language TEXT,
+            current_language TEXT,
+            prefer_multiple_choice INTEGER,
+            first_name TEXT,
+            last_name TEXT,
+            is_premium INTEGER,
+            user_name TEXT,
+            last_seen TEXT
+        );");
+        _repo = new UserRepository(_factory);
+    }
+
+    [Fact]
+    public async Task AddAndGetUserAsync()
+    {
+        var user = new User { Id = Guid.NewGuid(), Telegram_Id = 111, Last_Seen = DateTime.UtcNow };
+        await _repo.AddAsync(user);
+        var loaded = await _repo.GetByTelegramIdAsync(111);
+        Assert.NotNull(loaded);
+        Assert.Equal(user.Id, loaded!.Id);
+    }
+
+    [Fact]
+    public async Task UpdateUserAsync()
+    {
+        var user = new User { Id = Guid.NewGuid(), Telegram_Id = 222, Last_Seen = DateTime.UtcNow };
+        await _repo.AddAsync(user);
+        user.First_Name = "New";
+        await _repo.UpdateAsync(user);
+        var loaded = await _repo.GetByTelegramIdAsync(222);
+        Assert.Equal("New", loaded!.First_Name);
+    }
+
+    public void Dispose() => _factory.Dispose();
+}

--- a/TelegramWordBot.Tests/WordRepositoryTests.cs
+++ b/TelegramWordBot.Tests/WordRepositoryTests.cs
@@ -1,0 +1,66 @@
+using Dapper;
+using TelegramWordBot.Models;
+using TelegramWordBot.Repositories;
+using Xunit;
+
+public class WordRepositoryTests : IDisposable
+{
+static WordRepositoryTests() { SqlMapper.AddTypeHandler(new GuidTypeHandler()); }
+    private readonly TestDbConnectionFactory _factory;
+    private readonly WordRepository _repo;
+
+    public WordRepositoryTests()
+    {
+        _factory = new TestDbConnectionFactory();
+        using var conn = _factory.CreateConnection();
+        conn.Execute("CREATE TABLE languages (id INTEGER PRIMARY KEY, code TEXT, name TEXT);");
+        conn.Execute("CREATE TABLE words (id BLOB PRIMARY KEY, base_text TEXT NOT NULL, language_id INTEGER);");
+        _repo = new WordRepository(_factory);
+    }
+
+    [Fact]
+    public async Task AddAndGetWordAsync()
+    {
+        using (var conn = _factory.CreateConnection())
+        {
+            conn.Execute("INSERT INTO languages (id, code, name) VALUES (1, 'en', 'English');");
+        }
+        var word = new Word { Id = Guid.NewGuid(), Base_Text = "hello", Language_Id = 1 };
+        await _repo.AddWordAsync(word);
+        var loaded = await _repo.GetByTextAndLanguageAsync("hello", 1);
+        Assert.NotNull(loaded);
+        Assert.Equal(word.Id, loaded!.Id);
+    }
+
+    [Fact]
+    public async Task CountByLanguage_ReturnsCorrectCounts()
+    {
+        using (var conn = _factory.CreateConnection())
+        {
+            conn.Execute("INSERT INTO languages (id, code, name) VALUES (1, 'en','English'), (2, 'ru','Russian');");
+        }
+        await _repo.AddWordAsync(new Word { Id = Guid.NewGuid(), Base_Text = "one", Language_Id = 1 });
+        await _repo.AddWordAsync(new Word { Id = Guid.NewGuid(), Base_Text = "two", Language_Id = 1 });
+        await _repo.AddWordAsync(new Word { Id = Guid.NewGuid(), Base_Text = "odin", Language_Id = 2 });
+
+        var counts = await _repo.GetCountByLanguageAsync();
+
+        Assert.Equal(2, counts["English"]);
+        Assert.Equal(1, counts["Russian"]);
+    }
+
+    [Fact]
+    public async Task WordExistsAsync_ReturnsExpected()
+    {
+        using (var conn = _factory.CreateConnection())
+        {
+            conn.Execute("INSERT INTO languages (id, code, name) VALUES (1, 'en','English');");
+        }
+        await _repo.AddWordAsync(new Word { Id = Guid.NewGuid(), Base_Text = "test", Language_Id = 1 });
+
+        Assert.True(await _repo.WordExistsAsync("test", 1));
+        Assert.False(await _repo.WordExistsAsync("other", 1));
+    }
+
+    public void Dispose() => _factory.Dispose();
+}


### PR DESCRIPTION
## Summary
- refactor repository classes to use `IConnectionFactory` for easier testing
- add SQLite-based `TestDbConnectionFactory` and custom `GuidTypeHandler`
- implement unit tests for `LanguageRepository`, `WordRepository`, and `UserRepository`
- include Microsoft.Data.Sqlite in the test project

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c7b9dc47c832e91d9e89ac6a4504a