### PR TITLE
Add simple admin dashboard

### DIFF
--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using TelegramWordBot.Repositories;
 using TelegramWordBot.Services;
 using TelegramWordBot.Models;
+using System.Linq;
 
 namespace TelegramWordBot.Controllers;
 
@@ -14,37 +15,110 @@ public class AdminController : ControllerBase
     private readonly WordRepository _wordRepo;
     private readonly TranslationRepository _translationRepo;
     private readonly LanguageRepository _languageRepo;
+    private readonly IAIHelper _ai;
 
     public AdminController(
         WordImageRepository imageRepo,
         IImageService imageService,
         WordRepository wordRepo,
         TranslationRepository translationRepo,
-        LanguageRepository languageRepo)
+        LanguageRepository languageRepo,
+        IAIHelper ai)
     {
         _imageRepo = imageRepo;
         _imageService = imageService;
         _wordRepo = wordRepo;
         _translationRepo = translationRepo;
         _languageRepo = languageRepo;
+        _ai = ai;
+    }
+
+    [HttpGet("")]
+    public async Task<IActionResult> Index()
+    {
+        var total = await _wordRepo.GetTotalCountAsync();
+        var byLang = await _wordRepo.GetCountByLanguageAsync();
+        var withImg = await _imageRepo.CountWithImageAsync();
+        var withoutImg = await _imageRepo.CountWithoutImageAsync();
+
+        var html = $@"
+<html>
+<head>
+    <title>Admin Dashboard</title>
+    <style>
+        body {{ font-family: sans-serif; background:#fafbfc; color:#222; }}
+        h1 {{ color:#4267b2; }}
+        .link-btn {{ display:inline-block; margin-top:8px; background:#4267b2; color:#fff; padding:6px 14px; border-radius:8px; text-decoration:none; font-size:0.96em; }}
+        .link-btn:hover {{ background:#1a418e; }}
+        form {{ margin-bottom:20px; }}
+    </style>
+</head>
+<body>
+    <h1>Admin Dashboard</h1>
+    <p>Total words: {total}</p>
+    <p>With images: {withImg}, without images: {withoutImg}</p>
+    <ul>
+        {string.Join("", byLang.Select(l => $"<li>{System.Net.WebUtility.HtmlEncode(l.Key)}: {l.Value}</li>"))}
+    </ul>
+
+    <form method='post' action='/admin/generate'>
+        <input type='text' name='theme' placeholder='Theme' required> 
+        <input type='number' name='count' value='20' style='width:60px;'> 
+        <input type='text' name='sourceLang' placeholder='Source lang' value='English'> 
+        <input type='text' name='targetLang' placeholder='Target lang' value='Russian'>
+        <button class='link-btn' type='submit'>Generate</button>
+    </form>
+
+    <form method='post' action='/admin/images/download'>
+        <button class='link-btn' type='submit'>Download Images</button>
+    </form>
+
+    <form method='post' action='/admin/images/clear'>
+        <button class='link-btn' type='submit'>Clear Local Images</button>
+    </form>
+
+    <form method='post' action='/admin/delete'>
+        <button class='link-btn' style='background:#c00;' type='submit'>Delete All Words</button>
+    </form>
+</body>
+</html>";
+
+        return Content(html, "text/html; charset=utf-8");
     }
 
     [HttpPost("images/download")]
     public async Task<IActionResult> DownloadImages()
     {
         var words = (await _imageRepo.GetWordsWithoutImagesAsync()).ToList();
-        int success = 0;
-        int failed = 0;
         foreach (var w in words)
         {
-            var path = await _imageService.GetImagePathAsync(w);
-            if (string.IsNullOrEmpty(path))
-                failed++;
-            else
-                success++;
+            await _imageService.GetImagePathAsync(w);
         }
+        return RedirectToAction(nameof(Index));
+    }
 
-        return Ok(new { Total = words.Count(), Success = success, Failed = failed });
+    [HttpPost("images/clear")]
+    public async Task<IActionResult> ClearImages()
+    {
+        await _imageService.DeleteAllLocalImages();
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("generate")]
+    public async Task<IActionResult> Generate([FromForm] string theme, [FromForm] int count, [FromForm] string sourceLang, [FromForm] string targetLang)
+    {
+        var result = await _ai.GetWordByTheme(theme, count, targetLang, sourceLang);
+        await SaveGeneratedWordsAsync(result.Items);
+        return RedirectToAction(nameof(Index));
+    }
+
+    [HttpPost("delete")]
+    public async Task<IActionResult> DeleteAll()
+    {
+        await _imageService.DeleteAllLocalImages();
+        await _translationRepo.RemoveAllTranslations();
+        await _wordRepo.RemoveAllWords();
+        return RedirectToAction(nameof(Index));
     }
 
     private async Task SaveGeneratedWordsAsync(IEnumerable<TranslatedItem> items)


### PR DESCRIPTION
## Summary
- implement admin dashboard in `AdminController`
- add forms for generating words, downloading/clearing images and removing all words
- minimal styling follows the todo page style

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7e17e940832e880917aa58941944