### PR TITLE
Fix language input state on start

### DIFF
--- a/Worker.cs
+++ b/Worker.cs
@@ -542,7 +542,10 @@ namespace TelegramWordBot
             {
                 var (user, isNewUser) = await EnsureUserAsync(message);
                 if (isNewUser)
+                {
                     await SendWelcomeAsync(user, chatId, ct);
+                    return;
+                }
 
                 await filterMessages(message);
                 // Handle keyboard buttons first


### PR DESCRIPTION
## Summary
- avoid processing the `/start` message again after sending welcome message to a new user

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c8d0228f0832eafce0d29ea30ccef