### PR TITLE
Adjust word reset options and confirm stats reset

### DIFF
--- a/Services/KeyboardFactory.cs
+++ b/Services/KeyboardFactory.cs
@@ -31,7 +31,6 @@ public static class KeyboardFactory
             new[] { new KeyboardButton("Генерация новых слов") },
             new[] { new KeyboardButton("📝 Изменить слово") },
             new[] { new KeyboardButton("🗑️ Удалить слова") },
-            new[] { new KeyboardButton("♻️ Обнулить прогресс слов") },
             new[] { new KeyboardButton("⬅️ Назад") }
         })
         {

--- a/Worker.cs
+++ b/Worker.cs
@@ -137,10 +137,6 @@ namespace TelegramWordBot
                     await ShowMyWordsForEdit(chatId, user, ct);
                     return (true, "awaiting_listdelete");
 
-                case "♻️ обнулить прогресс слов":
-                    await ResetAllWordProgress(chatId, user, ct);
-                    return (true, string.Empty);
-
                 case "⬅️ назад":
                     await KeyboardFactory.ShowMainMenuAsync(_botClient, chatId, ct);
                     return (true, string.Empty);
@@ -274,7 +270,18 @@ namespace TelegramWordBot
                     await ShowProfileInfo(user, chatId, ct);
                     break;
                 case "reset_profile_stats":
-                    await ResetProfileStatistics(user, chatId, ct);
+                    if (parts.Length > 1 && parts[1] == "confirm")
+                    {
+                        await ResetProfileStatistics(user, chatId, ct);
+                    }
+                    else
+                    {
+                        await _msg.SendConfirmationDialog(chatId,
+                            "Сбросить статистику?",
+                            "reset_profile_stats:confirm",
+                            "cancel",
+                            ct);
+                    }
                     break;
                 case "edit_dict":
                     await EditDictionary(parts[1], chatId, ct);


### PR DESCRIPTION
## Summary
- clean up the "Мои слова" menu
- prompt for confirmation before resetting profile statistics

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e87728568832e883233db6bec3cb9