### PR TITLE
Fix Gemini TTS request structure

### DIFF
--- a/Services/TTS/GeminiSpeechService.cs
+++ b/Services/TTS/GeminiSpeechService.cs
@@ -21,23 +21,25 @@ public class GeminiSpeechService : ITextToSpeechService
         const string modelId = "gemini-2.5-pro-preview-tts";
         var request = new
         {
-            contents = new []
+            contents = new[]
             {
-                new {
+                new
+                {
                     role = "user",
-                    parts = new [] { new { text } }
+                    parts = new[] { new { text } }
                 }
             },
             generationConfig = new
             {
-                responseModalities = new [] { "audio" },
+                responseModalities = new[] { "audio" },
                 temperature = 1,
-                speech_config = new
+                speechConfig = new
                 {
-                    voice = new
+                    voiceConfig = new
                     {
-                        prebuilt_voice = new { voice_name = voiceName }
-                    }
+                        prebuiltVoiceConfig = new { voiceName }
+                    },
+                    languageCode = languageCode
                 }
             }
         };


### PR DESCRIPTION
## Summary
- correct property names for Gemini text-to-speech API

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685038d4a97c832e9bde08b93f7ea206