### PR TITLE
Switch TTS service to Google API

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -27,7 +27,7 @@ builder.Services.AddSingleton<ITelegramBotClient>(new TelegramBotClient(tokenTG)
 
 var ttsOptions = Worker.GetDefaultTtsOptions();
 builder.Services.AddSingleton(ttsOptions);
-builder.Services.AddHttpClient<ITextToSpeechService, GeminiSpeechService>();
+builder.Services.AddHttpClient<ITextToSpeechService, GoogleTextToSpeechService>();
 
 connectionString = DbConnectionFactory.ConvertDatabaseUrl(connectionString);
 var dbFactory = new DbConnectionFactory(connectionString);


### PR DESCRIPTION
## Summary
- use `GoogleTextToSpeechService` in DI
- extend Google TTS client to allow API key or bearer token

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*
- `curl https://texttospeech.googleapis.com/v1/text:synthesize` *(403 due to missing credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68503ec93d8c832e8d45b6448b107051