### PR TITLE
Ensure receive_reminders column exists

### DIFF
--- a/DbInitializer.cs
+++ b/DbInitializer.cs
@@ -30,6 +30,7 @@ public static class DatabaseInitializer
                 last_seen TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                 receive_reminders BOOLEAN NOT NULL DEFAULT TRUE
             );",
+            @"ALTER TABLE users ADD COLUMN IF NOT EXISTS receive_reminders BOOLEAN NOT NULL DEFAULT TRUE;",
             @"CREATE TABLE IF NOT EXISTS words (
                 id UUID PRIMARY KEY,
                 base_text TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- make `DatabaseInitializer` add `receive_reminders` column when missing

## Testing
- `dotnet build TelegramWordBot.sln`
- `dotnet test TelegramWordBot.sln`


------
https://chatgpt.com/codex/tasks/task_e_689f4c61a464832ea7ef872095d84918