### PR TITLE
Refresh PostgreSQL collation on startup

### DIFF
--- a/DbInitializer.cs
+++ b/DbInitializer.cs
@@ -5,6 +5,14 @@ namespace TelegramWordBot;
 
 public static class DatabaseInitializer
 {
+    public static async Task RefreshCollationAsync(DbConnectionFactory factory)
+    {
+        using var connection = factory.CreateConnection();
+        var dbName = connection.Database;
+        await connection.ExecuteAsync($"REINDEX DATABASE \"{dbName}\";");
+        await connection.ExecuteAsync($"ALTER DATABASE \"{dbName}\" REFRESH COLLATION VERSION;");
+    }
+
     public static async Task EnsureTablesAsync(DbConnectionFactory factory)
     {
         using var connection = factory.CreateConnection();

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,7 @@ builder.Services.AddHttpClient<ITextToSpeechService, GoogleTextToSpeechService>(
 
 connectionString = DbConnectionFactory.ConvertDatabaseUrl(connectionString);
 var dbFactory = new DbConnectionFactory(connectionString);
+await DatabaseInitializer.RefreshCollationAsync(dbFactory);
 await DatabaseInitializer.EnsureTablesAsync(dbFactory);
 await DatabaseInitializer.EnsureLanguagesAsync(dbFactory);
 builder.Services.AddSingleton<IConnectionFactory>(new DbConnectionFactory(connectionString));


### PR DESCRIPTION
## Summary
- reindex and refresh PostgreSQL collation version during application startup to fix collation mismatch

## Testing
- `dotnet build TelegramWordBot.sln`
- `dotnet test TelegramWordBot.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b96a5af5f8832eb4449da82aeab7dd